### PR TITLE
API Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Django #
+#################
+*.egg-info
+
 .env
 *.pyc
 db.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,15 @@
 #################
 *.egg-info
 
+# Coverage #
+############
+.coverage
+htmlcov/
+
+# OS Files #
+############
+.DS_Store
+
 .env
 *.pyc
 db.sqlite3
-.coverage

--- a/ccdb5_api/settings.py
+++ b/ccdb5_api/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'rest_framework',
     'complaint_search',
+    'rest_framework_swagger',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -73,6 +74,16 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'ccdb5_api.wsgi.application'
 
+SWAGGER_SETTINGS = {
+    'info': {
+          "title": "CCDB API",
+          "description": "This is api for Consumer Complaint Database application.",
+          "termsOfServiceUrl": "",
+          "contact": "info@cfpb.gov",
+          "license": "Apache 2.0",
+          "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+}
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases

--- a/complaint_search/tests/test_views_search.py
+++ b/complaint_search/tests/test_views_search.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 from unittest import skip
@@ -23,6 +24,18 @@ class SearchTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_essearch.assert_called_once_with()
         self.assertEqual('OK', response.data)
+
+    @mock.patch('complaint_search.es_interface.search')
+    def test_search_cors_headers(self, mock_essearch):
+        """
+        Make sure the response has CORS headers in debug mode
+        """
+        settings.DEBUG = True
+        url = reverse('complaint_search:search')
+        mock_essearch.return_value = 'OK'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.has_header('Access-Control-Allow-Origin'))
 
     # @mock.patch('complaint_search.es_interface.search')
     # def test_search_with_fmt(self, mock_essearch):

--- a/complaint_search/urls.py
+++ b/complaint_search/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import include, url
 import complaint_search.views
 
 urlpatterns = [
+	url(r'^docs/', include('rest_framework_swagger.urls')),
     url(r'^_suggest', complaint_search.views.suggest, name="suggest"),
     url(r'^(?P<id>[0-9]+)$', complaint_search.views.document, name="document"),
     url(r'^$', complaint_search.views.search, name="search"),

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -2,6 +2,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from django.http import JsonResponse
+from django.conf import settings
 import datetime
 import es_interface
 from complaint_search.serializer import SearchInputSerializer, SuggestInputSerializer
@@ -42,7 +43,16 @@ def search(request):
         #     "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         # }
 
-        return Response(results)#, 
+        # Local development requires CORS support
+        headers = {}
+        if settings.DEBUG:
+            headers = {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+                'Access-Control-Allow-Methods': 'GET'
+            }
+
+        return Response(results, headers=headers)#,
             # content_type=FMT_CONTENT_TYPE_MAP.get(serializer.validated_data.get("fmt", 'json')))
     else:
         return Response(serializer.errors,

--- a/complaint_search/views.py
+++ b/complaint_search/views.py
@@ -1,3 +1,6 @@
+#!/usr/local/bin/python
+# coding: utf-8
+
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -9,6 +12,177 @@ from complaint_search.serializer import SearchInputSerializer, SuggestInputSeria
 
 @api_view(['GET'])
 def search(request):
+    """
+    Search through everything in Consumer Complaints
+    ---
+    parameters:
+        - name: format
+          in: query
+          description: Format to be returned
+          required: false
+          type: string
+          enum:
+            - json
+            - csv
+            - xls
+            - xlsx
+          default: json
+          collectionFormat: multi
+        - name: field
+          in: query
+          description: Search by particular field
+          required: false
+          type: array
+          items:
+          type: string
+          enum:
+            - complaint_what_happened
+            - company_public_response
+            - all
+          default: all
+          collectionFormat: multi
+        - name: size
+          in: query
+          description: Limit the size of the search result
+          required: false
+          type: integer
+          maximum: 100000
+          minimum: 1
+          format: int64
+        - name: from
+          in: query
+          description: Return results starting from a specific index
+          required: false
+          type: integer
+          maximum: 100000
+          minimum: 1
+          format: int64
+        - name: sort
+          in: query
+          description: Return results sort in a particular order
+          required: false
+          type: string
+          enum:
+            - "-relevance"
+            - "+relevance"
+            - "-created_date"
+            - "+created_date"
+          default: "-relevance"
+        - name: search_term
+          in: query
+          description: Return results containing specific term
+          required: false
+          type: string
+        - name: min_date
+          in: query
+          description: Return results with date >= min_date (i.e. 2017-03-04)
+          required: false
+          type: string
+          format: date
+        - name: max_date
+          in: query
+          description: Return results with date < max_date (i.e. 2017-03-04)
+          required: false
+          type: string
+          format: date
+        - name: company
+          in: query
+          description: Filter the results to only return these companies
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: product
+          in: query
+          description: "Filter the results to only return these types of product and subproduct, i.e. product-only: Mortgage, subproduct needs to include product, separated by '•', U+2022: Mortgage•FHA mortgage"
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: issue
+          in: query
+          description: "Filter the results to only return these types of issue and subissue, i.e. product-only: Getting a Loan, subproduct needs to include product, separated by '•', U+2022: Getting a Loan•Can't qualify for a loan"
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: state
+          in: query
+          description: Filter the results to only return these states (use abbreviation, i.e. CA, VA)
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: consumer_disputed
+          in: query
+          description: Filter the results to only return the specified state of consumer disputed, i.e. yes, no
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: company_response
+          in: query
+          description: Filter the results to only return these types of response by the company
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: company_public_response
+          in: query
+          description: Filter the results to only return these types of public response by the company
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: consumer_consent_provided
+          in: query
+          description: Filter the results to only return these types of consent consumer provided
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: submitted_via
+          in: query
+          description: Filter the results to only return these types of way consumers submitted their complaints
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: tag
+          in: query
+          description: Filter the results to only return these types of tag
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+        - name: has_narratives
+          in: query
+          description: Filter the results to only return the specified state of whether it has narrative in the complaint or not, i.e. yes, no
+          required: false
+          type: array
+          items: 
+          type: string
+          collectionFormat: multi
+    responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Complaint'
+        400:
+          description: "Invalid status value"
+    """
     fixed_qparam = request.query_params
     QPARAMS_VARS = ('fmt', 'field', 'size', 'frm', 'sort', 
         'search_term', 'min_date', 'max_date')
@@ -60,6 +234,30 @@ def search(request):
 
 @api_view(['GET'])
 def suggest(request):
+    """
+    Automcomplete for the Search of consumer complaints
+    ---
+    parameters:
+        - name: size
+          in: query
+          description: number of suggestions to return, default 6
+          required: true
+          type: integer
+        - name: text
+          in: query
+          description: text to find suggestions on
+          required: true
+          type: string
+    responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: array
+            items:
+              type: "string"
+        400:
+          description: "Invalid input"
+    """
     QPARAMS_VARS = ("text", "size")
     data = { k:v for k,v in request.query_params.iteritems() if k in QPARAMS_VARS }
     serializer = SuggestInputSerializer(data=data)
@@ -70,7 +268,30 @@ def suggest(request):
         return Response(serializer.errors,
             status=status.HTTP_400_BAD_REQUEST)
 
+
 @api_view(['GET'])
 def document(request, id):
+    """
+    Find comsumer complaint by ID
+    ---
+    parameters:
+        - name: complaintId
+          in: path
+          description: ID of the complaint
+          required: true
+          type: integer
+          maximum: 9999999999
+          minimum: 0
+          format: int64
+    responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: array
+            items:
+              type: "string"
+        400:
+          description: "Invalid input"
+    """
     results = es_interface.document(id)
     return Response(results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django>=1.8,<=1.8.99
 djangorestframework==3.1.3
+django-rest-swagger==0.3.0
 elasticsearch==2.4.1
 requests==2.14.2
 urllib3==1.21.1


### PR DESCRIPTION
Converted the API documentation for the CCDB 5 from [the gist](https://github.com/cfpb/ccdb5-api/wiki/API-Specification) to Swagger.io for the `search`, `suggest`, and `document` endpoints. Also added a new endpoint `/docs/` to view the documentation via the Swagger UI.

Reviewers:
@amymok 

To Do:
* The `search` and `document` endpoints are not named, causing the Swagger UI to not display them